### PR TITLE
Patch to find Rterm.exe in i386/ and x86/ bin hierarchies

### DIFF
--- a/lib/rinruby.rb
+++ b/lib/rinruby.rb
@@ -771,7 +771,7 @@ def initialize(*args)
     else
       path.gsub!('\\','/')
     end
-    for hierarchy in [ 'bin', 'bin/i386', 'bin/x86' ]
+    for hierarchy in [ 'bin', 'bin/i386', 'bin/x64' ]
       target = "#{path}/#{hierarchy}/Rterm.exe"
       if File.exists? target
         return %Q<"#{target}">


### PR DESCRIPTION
This was posing a problem for our Windows users -- this fix (or one like it) makes it go away.

p.s. rinruby is awesome!
