### PR TITLE
Disable Nagle's algorithm in server and client

### DIFF
--- a/lib/rinruby.rb
+++ b/lib/rinruby.rb
@@ -168,6 +168,7 @@ def initialize(*args)
       #{RinRuby_KeepTrying_Variable} <- TRUE
       while ( #{RinRuby_KeepTrying_Variable} ) {
         #{RinRuby_Socket} <- try(suppressWarnings(socketConnection("#{@hostname}", #{@port_number}, blocking=TRUE, open="rb")),TRUE)
+        setTCPNoDelay(#{RinRuby_Socket}, value=TRUE)
         if ( inherits(#{RinRuby_Socket},"try-error") ) {
           Sys.sleep(0.1)
         } else {
@@ -180,6 +181,7 @@ def initialize(*args)
     r_rinruby_pull
     r_rinruby_parseable
     @socket = @server_socket.accept
+    @socket.setsockopt(Socket::IPPROTO_TCP, Socket::TCP_NODELAY, 1)
     echo(nil,true) if @platform =~ /.*-java/      # Redirect error messages on the Java platform
   end
 


### PR DESCRIPTION
This commit disables the Nagle's algorithm to reduce delay when
exchanging values between R and Ruby.

In a particular program I'm working on, I noticed that the exchange
of values between R and Ruby was more time consuming than 
the complex calculation itself.

An example of the Naggle impact here:
http://stackoverflow.com/questions/16776975/ruby-socket-performance-characteristics

Ref.
http://svitsrv25.epfl.ch/R-doc/library/gtools/html/setTCPNoDelay.html
