### PR TITLE
improve signal handling so that it exits gracefully

### DIFF
--- a/lib/rinruby.rb
+++ b/lib/rinruby.rb
@@ -246,7 +246,7 @@ def initialize(*args)
     else
       raise ParseError, "Parse error on eval:#{string}"
     end
-    Signal.trap('INT') do
+    old_handler = Signal.trap('INT') do
       puts "#{__FILE__}:#{__LINE__} GOT INT"
       @writer.print ''
       @reader.gets if @platform !~ /java/
@@ -285,9 +285,7 @@ def initialize(*args)
         $stdout.flush if @platform !~ /windows/
       end
     end
-    Signal.trap('INT') do
-      puts "#{__FILE__}:#{__LINE__} GOT INT"
-    end
+    Signal.trap('INT', old_handler)
     true
   end
 

--- a/lib/rinruby.rb
+++ b/lib/rinruby.rb
@@ -247,9 +247,11 @@ def initialize(*args)
       raise ParseError, "Parse error on eval:#{string}"
     end
     Signal.trap('INT') do
+      puts "#{__FILE__}:#{__LINE__} GOT INT"
       @writer.print ''
       @reader.gets if @platform !~ /java/
       Signal.trap('INT') do
+        puts "#{__FILE__}:#{__LINE__} GOT INT"
       end
       return true
     end
@@ -284,6 +286,7 @@ def initialize(*args)
       end
     end
     Signal.trap('INT') do
+      puts "#{__FILE__}:#{__LINE__} GOT INT"
     end
     true
   end


### PR DESCRIPTION
Previously it was often difficult to kill a rails server if rinruby had run. Rinruby would trap INT and do nothing, effectively preventing a user from canceling a running server. 

The concept of these changes is to reset the trap to its original state after the trap established by rinruby is no longer needed. I'm not sure this is correct. 

Thank you.
