### PR TITLE
Change strategy to find R executable for cygwin-windows

### DIFF
--- a/lib/rinruby.rb
+++ b/lib/rinruby.rb
@@ -767,15 +767,17 @@ def initialize(*args)
       path = `cygpath '#{path}'`
       while path.chomp!
       end
-      path.gsub!(' ','\ ')
+      path = [path.gsub(' ','\ '), path]
     else
-      path.gsub!('\\','/')
+      path = [path.gsub('\\','/')]
     end
-    for hierarchy in [ 'bin', 'bin/i386', 'bin/x64' ]
-      target = "#{path}/#{hierarchy}/Rterm.exe"
-      if File.exists? target
-        return %Q<"#{target}">
-      end
+    for hierarchy in [ 'bin', 'bin/x64', 'bin/i386']
+      path.each{|item|
+        target = "#{item}/#{hierarchy}/Rterm.exe"
+        if File.exists? target
+          return %Q<"#{target}">
+        end
+      }
     end
     raise "Cannot locate R executable"
   end


### PR DESCRIPTION
* Ruby on new cygwin cannot find path including white space with escape such as "/cygdrive/c/Program\\ Files/hoge", but find path including just white space "/cygdrive/c/Program Files/hoge". Therefore, both ' ' and '\ ' are used to find R executable.
* bin/x64 is preferred than bin/i386