### PR TITLE
Improve windows binary lookup including cygwin

### DIFF
--- a/lib/rinruby.rb
+++ b/lib/rinruby.rb
@@ -770,7 +770,18 @@ def initialize(*args)
       end
       break if path != '?'
     end
-    raise "Cannot locate R executable" if path == '?'
+    if path == '?'
+      # search at default install path
+      path = [
+        "Program Files",
+        "Program Files (x86)"
+      ].collect{|prog_dir|
+        Dir::glob(File::join(
+            cygwin ? "/cygdrive/c" : "C:",
+            prog_dir, "R", "*"))
+      }.flatten[0]
+      raise "Cannot locate R executable" unless path
+    end
     if cygwin
       path = `cygpath '#{path}'`
       while path.chomp!

--- a/lib/rinruby.rb
+++ b/lib/rinruby.rb
@@ -767,15 +767,17 @@ def initialize(*args)
       path = `cygpath '#{path}'`
       while path.chomp!
       end
-      path.gsub!(' ','\ ')
+      path = [path.gsub(' ','\ '), path]
     else
-      path.gsub!('\\','/')
+      path = [path.gsub('\\','/')]
     end
-    for hierarchy in [ 'bin', 'bin/i386', 'bin/x64' ]
-      target = "#{path}/#{hierarchy}/Rterm.exe"
-      if File.exists? target
-        return %Q<"#{target}">
-      end
+    for hierarchy in [ 'bin', 'bin/x64', 'bin/i386']
+      path.each{|item|
+        target = "#{item}/#{hierarchy}/Rterm.exe"
+        if File.exists? target
+          return %Q<"#{target}">
+        end
+      }
     end
     raise "Cannot locate R executable"
   end

--- a/lib/rinruby.rb
+++ b/lib/rinruby.rb
@@ -753,20 +753,40 @@ def initialize(*args)
   def find_R_on_windows(cygwin)
     path = '?'
     for root in [ 'HKEY_LOCAL_MACHINE', 'HKEY_CURRENT_USER' ]
-      proc{|str| # Remove invalid byte sequence
-        if RUBY_VERSION >= "2.1.0" then
-          str.scrub
-        elsif RUBY_VERSION >= "1.9.0" then
-          str.chars.collect{|c| (c.valid_encoding?) ? c : '*'}.join
-        else
-          str
+      if cygwin then
+        [:w, :W].collect{|opt| # [64bit, then 32bit registry]
+          [:R64, :R].collect{|mode|
+            `regtool list -#{opt} /#{root}/Software/R-core/#{mode} 2>/dev/null`.lines.collect{|v|
+              v =~ /^\d\.\d\.\d/ ? $& : nil
+            }.compact.sort{|a, b| # latest version has higher priority
+              b <=> a
+            }.collect{|ver|
+              ["-#{opt}", "/#{root}/Software/R-core/#{mode}/#{ver}/InstallPath"]
+            }
+          }
+        }.flatten(2).each{|args|
+          v = `regtool get #{args.join(' ')}`.chomp
+          unless v.empty? then
+            path = v
+            break
+          end
+        }
+      else
+        proc{|str| # Remove invalid byte sequence
+          if RUBY_VERSION >= "2.1.0" then
+            str.scrub
+          elsif RUBY_VERSION >= "1.9.0" then
+            str.chars.collect{|c| (c.valid_encoding?) ? c : '*'}.join
+          else
+            str
+          end
+        }.call(`reg query "#{root}\\Software\\R-core" /v "InstallPath" /s`).each_line do |line|
+          next if line !~ /^\s+InstallPath\s+REG_SZ\s+(.*)/
+          path = $1
+          while path.chomp!
+          end
+          break
         end
-      }.call(`reg query "#{root}\\Software\\R-core" /v "InstallPath" /s`).each_line do |line|
-        next if line !~ /^\s+InstallPath\s+REG_SZ\s+(.*)/
-        path = $1
-        while path.chomp!
-        end
-        break
       end
       break if path != '?'
     end

--- a/lib/rinruby.rb
+++ b/lib/rinruby.rb
@@ -753,7 +753,15 @@ def initialize(*args)
   def find_R_on_windows(cygwin)
     path = '?'
     for root in [ 'HKEY_LOCAL_MACHINE', 'HKEY_CURRENT_USER' ]
-      `reg query "#{root}\\Software\\R-core\\R" /v "InstallPath" /s`.split("\n").each do |line|
+      proc{|str| # Remove invalid byte sequence
+        if RUBY_VERSION >= "2.1.0" then
+          str.scrub
+        elsif RUBY_VERSION >= "1.9.0" then
+          str.chars.collect{|c| (c.valid_encoding?) ? c : '*'}.join
+        else
+          str
+        end
+      }.call(`reg query "#{root}\\Software\\R-core" /v "InstallPath" /s`).each_line do |line|
         next if line !~ /^\s+InstallPath\s+REG_SZ\s+(.*)/
         path = $1
         while path.chomp!

--- a/lib/rinruby.rb
+++ b/lib/rinruby.rb
@@ -753,7 +753,7 @@ def initialize(*args)
   def find_R_on_windows(cygwin)
     path = '?'
     for root in [ 'HKEY_LOCAL_MACHINE', 'HKEY_CURRENT_USER' ]
-      `reg query "#{root}\\Software\\R-core\\R" /v "InstallPath"`.split("\n").each do |line|
+      `reg query "#{root}\\Software\\R-core\\R" /v "InstallPath" /s`.split("\n").each do |line|
         next if line !~ /^\s+InstallPath\s+REG_SZ\s+(.*)/
         path = $1
         while path.chomp!


### PR DESCRIPTION
This is an update to improve Windows R binary search strategy.
The update can deal with the following changes:

- Registry structure registered by R
- Cygwin path handling,

and the update is backward compatible, which include the previous strategies, except for one thing:

- 64-bits binary may be preferred than x86
