### PR TITLE
RSpec test refactoring

### DIFF
--- a/rinruby.gemspec
+++ b/rinruby.gemspec
@@ -19,6 +19,6 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_development_dependency "rake"
-  spec.add_development_dependency "rspec"
+  spec.add_development_dependency "rspec", ">= 2.11"
   spec.add_development_dependency "hoe"
 end

--- a/spec/rinruby_spec.rb
+++ b/spec/rinruby_spec.rb
@@ -4,46 +4,40 @@ puts "RinRuby #{RinRuby::VERSION} specification"
 
 describe RinRuby do
   describe "on init" do
+    let(:params){
+      {
+        :echo_enabled => false, 
+        :interactive => false, 
+        :executable => nil, 
+        :port_number => 38500, 
+        :port_width => 1,
+      }
+    }
+    let(:r){
+      RinRuby.new(*([:echo_enabled, :interactive, :executable, :port_number, :port_width].collect{|k| params[k]}))
+    }
     it "should accept parameters as specified on Dahl & Crawford(2009)" do
-      
-      platform = case RUBY_PLATFORM
-      when /mswin/ then 'windows'
-      when /mingw/ then 'windows'
-      when /bccwin/ then 'windows'
-      else 
-        "other"
-      end
-      if platform=='windows'
-        skip("Difficult to test without specific location of R executable on Windows")
-      else      
-      
-      r=RinRuby.new(false, false, "R", 38500, 1)
-      
-      expect(r.echo_enabled).to be false
-      r.interactive.should be false
-      r.executable.should=="R"
-      r.port_number.should==38500
-      r.port_width.should==1      
-      end
+      expect(r.echo_enabled).to be_falsy
+      expect(r.interactive).to be_falsy
+      expect(r.port_number).to eq(params[:port_number])
+      expect(r.port_width).to eq(params[:port_width])
+      case r.instance_variable_get(:@platform)
+      when /^windows/ then
+        expect(r.executable).to match(/Rterm\.exe["']?$/)
+      else
+        expect(r.executable).to eq("R")
+      end      
     end
-    it "should accept :echo and :interactive parameters" do
-      r=RinRuby.new(:echo=>false, :interactive=>false)
-      r.echo_enabled.should be false
-      r.interactive.should be false
-      
+    it "should accept custom :port_number" do
+      params.merge!(:port_number => 38442+rand(3))
+      expect(r.port_number).to eq(params[:port_number])
     end
-    it "should accept :port_number" do
-      port=38442+rand(3)
-      r=RinRuby.new(:port_number=>port,:port_width=>1)
-      r.port_number.should==port
-      r.quit
-    end
-    it "should accept :port_width" do
-      port=38442
-      port_width=rand(10)+1
-      r=RinRuby.new(:port=>port, :port_width=>port_width)
-      expect(r.port_width).to be == port_width
-      r.port_number.should satisfy {|v| v>=port and v < port+port_width}
+    it "should accept custom :port_width" do
+      params.merge!(:port_number => 38442, :port_width => rand(10)+1)
+      expect(r.port_width).to eq(params[:port_width])
+      expect(r.port_number).to satisfy {|v| 
+        ((params[:port_number])...(params[:port_number] + params[:port_width])).include?(v)
+      }
     end
   end
   before do
@@ -51,82 +45,80 @@ describe RinRuby do
   end
   subject {R}
   context "basic methods" do 
-    it {should respond_to :eval}
-    it {should respond_to :quit}
-    it {should respond_to :assign}
-    it {should respond_to :pull}
-    it {should respond_to :quit}
-    it {should respond_to :echo}
+    it {is_expected.to respond_to(:eval)}
+    it {is_expected.to respond_to(:quit)}
+    it {is_expected.to respond_to(:assign)}
+    it {is_expected.to respond_to(:pull)}
+    it {is_expected.to respond_to(:quit)}
+    it {is_expected.to respond_to(:echo)}
     it "return correct values for complete?" do
-      R.eval("x<-1").should be true
+      expect(R.eval("x<-1")).to be_truthy
     end
     it "return false for complete? for incorrect expressions" do
-      R.complete?("x<-").should be false
+      expect(R.complete?("x<-")).to be_falsy
     end
     it "correct eval should return true" do 
-      R.complete?("x<-1").should be true
+      expect(R.complete?("x<-1")).to be_truthy
     end
     it "incorrect eval should raise an ParseError" do
-      lambda {R.eval("x<-")}.should raise_error(RinRuby::ParseError)
+      expect{R.eval("x<-")}.to raise_error(RinRuby::ParseError)
     end
   end
-  context "on assing" do 
+  context "on assing" do
+    let(:x){rand} 
     it "should assign correctly" do
-      x=rand
       R.assign("x",x)
-      R.pull("x").should==x
+      expect(R.pull("x")).to eq(x)
     end
     it "should be the same using assign than R#= methods" do
-      x=rand
       R.assign("x1",x)
       R.x2=x
-      R.pull("x1").should==x
-      R.pull("x2").should==x
+      expect(R.pull("x1")).to eq(x)
+      expect(R.pull("x2")).to eq(x)
     end
     it "should raise an ArgumentError error on setter with 0 parameters" do
-      lambda {R.unknown_method=() }.should raise_error(ArgumentError)
+      expect{R.unknown_method=() }.to raise_error(ArgumentError)
     end
-    
   end
   context "on pull" do
     it "should be the same using pull than R# methods" do
       x=rand
       R.x=x
-      R.pull("x").should==x
-      R.x.should==x
+      expect(R.pull("x")).to eq(x)
+      expect(R.x).to eq(x)
     end
     it "should raise an NoMethod error on getter with 1 or more parameters" do
-      lambda {R.unknown_method(1) }.should raise_error(NoMethodError)
+      expect{R.unknown_method(1) }.to raise_error(NoMethodError)
     end
     
     it "should pull a String" do
       R.eval("x<-'Value'")
-      R.pull('x').should=='Value'
+      expect(R.pull('x')).to eq('Value')
     end
     it "should pull an Integer" do
       R.eval("x<-1")
-      R.pull('x').should==1
+      expect(R.pull('x')).to eq(1)
     end
     it "should pull a Float" do
       R.eval("x<-1.5")
-      R.pull('x').should==1.5
+      expect(R.pull('x')).to eq(1.5)
     end
     it "should pull an Array of Numeric" do
       R.eval("x<-c(1,2.5,3)")
-      R.pull('x').should==[1,2.5,3]
+      expect(R.pull('x')).to eq([1,2.5,3])
     end
     it "should pull an Array of strings" do
       R.eval("x<-c('a','b')")
-      R.pull('x').should==['a','b']
+      expect(R.pull('x')).to eq(['a','b'])
     end
 
     it "should push a Matrix" do
       matrix=Matrix::build(100, 200){|i, j| rand} # 100 x 200 matrix
-      lambda {R.assign('x',matrix)}.should_not raise_error
+      expect{R.assign('x',matrix)}.not_to raise_error
       rx=R.x
       matrix.row_size.times {|i|
         matrix.column_size.times {|j|
-          matrix[i,j].should be_within(1e-10).of(rx[i,j])
+          expect(matrix[i,j]).to be_within(1e-10).of(rx[i,j])
         }
       }
     end
@@ -134,17 +126,13 @@ describe RinRuby do
   end
 
   context "on quit" do
-    before(:each) do
-      @r=RinRuby.new(:echo=>false)
-    end
+    let(:r){RinRuby.new(:echo=>false)}
     it "return true" do
-      @r.quit.should be true
+      expect(r.quit).to be_truthy
     end
     it "returns an error if used again" do
-      @r.quit
-      lambda {@r.eval("x=1")}.should raise_error(RinRuby::EngineClosed)
+      r.quit
+      expect{r.eval("x=1")}.to raise_error(RinRuby::EngineClosed)
     end
   end
-  
-
 end

--- a/spec/rinruby_spec.rb
+++ b/spec/rinruby_spec.rb
@@ -23,6 +23,11 @@ shared_examples 'RinRubyCore' do
         expect(r.executable).to eq("R")
       end      
     end
+    it "should accept :echo and :interactive parameters" do
+      params.merge!(:echo_enabled => true, :interactive => true)
+      expect(r.echo_enabled).to be_truthy
+      expect(r.interactive).to be_truthy
+    end
     it "should accept custom :port_number" do
       params.merge!(:port_number => 38442+rand(3), :port_width => 1)
       expect(r.port_number).to eq(params[:port_number])
@@ -35,9 +40,14 @@ shared_examples 'RinRubyCore' do
       }
     end
   end
+  
   describe "R interface" do
+    # In before(:each) or let(including subject) blocks, Assignment to instance variable 
+    # having a same name defined in before(:all) will not work intentionally, 
+    # because a new instance variable will be created for the following examples.
+    # For workaround, two-step indirect assignment to a hash created in before(:all) is applied. 
     before(:all){@cached_env = {:r => nil}} # make placeholder
-    subject{@cached_env[:r] ||= r}
+    subject{@cached_env[:r] ||= r} 
     describe "basic methods" do 
       it {is_expected.to respond_to(:eval)}
       it {is_expected.to respond_to(:assign)}
@@ -83,7 +93,7 @@ shared_examples 'RinRubyCore' do
       it "should raise an NoMethod error on getter with 1 or more parameters" do
         expect{subject.unknown_method(1) }.to raise_error(NoMethodError)
       end
-      
+
       it "should pull a String" do
         subject.eval("x<-'Value'")
         expect(subject.pull('x')).to eq('Value')
@@ -104,7 +114,7 @@ shared_examples 'RinRubyCore' do
         subject.eval("x<-c('a','b')")
         expect(subject.pull('x')).to eq(['a','b'])
       end
-  
+
       it "should push a Matrix" do
         matrix=Matrix::build(100, 200){|i, j| rand} # 100 x 200 matrix
         expect{subject.assign('x',matrix)}.not_to raise_error
@@ -117,6 +127,7 @@ shared_examples 'RinRubyCore' do
       end
     end
   end
+  
   context "on quit" do
     it "return true" do
       expect(r.quit).to be_truthy

--- a/spec/rinruby_spec.rb
+++ b/spec/rinruby_spec.rb
@@ -2,23 +2,10 @@ require File.expand_path(File.dirname(__FILE__) + '/spec_helper')
 require 'rinruby'
 puts "RinRuby #{RinRuby::VERSION} specification"
 
-describe RinRuby do
-  let(:params){
-    {
-      :echo_enabled => false, 
-      :interactive => false, 
-      :executable => nil, 
-      :port_number => 38500, 
-      :port_width => 1,
-    }
-  }
-  let(:r){
-    RinRuby.new(*([:echo_enabled, :interactive, :executable, :port_number, :port_width].collect{|k| params[k]}))
-  }
-  subject{R}
-  before do
-    subject.echo(false)
-  end
+shared_examples 'RinRubyCore' do
+  #before{
+  #  subject.echo(false)
+  #}
   describe "on init" do
     it "should accept parameters as specified on Dahl & Crawford(2009)" do
       expect(r.echo_enabled).to be_falsy
@@ -44,83 +31,87 @@ describe RinRuby do
       }
     end
   end
-  describe "basic methods" do 
-    it {is_expected.to respond_to(:eval)}
-    it {is_expected.to respond_to(:quit)}
-    it {is_expected.to respond_to(:assign)}
-    it {is_expected.to respond_to(:pull)}
-    it {is_expected.to respond_to(:quit)}
-    it {is_expected.to respond_to(:echo)}
-    it "return correct values for complete?" do
-      expect(subject.eval("x<-1")).to be_truthy
+  describe "R interface" do
+    subject{
+      R_INSTANCE ||= r
+    }
+    describe "basic methods" do 
+      it {is_expected.to respond_to(:eval)}
+      it {is_expected.to respond_to(:assign)}
+      it {is_expected.to respond_to(:pull)}
+      it {is_expected.to respond_to(:quit)}
+      it {is_expected.to respond_to(:echo)}
+      it "return correct values for complete?" do
+        expect(subject.eval("x<-1")).to be_truthy
+      end
+      it "return false for complete? for incorrect expressions" do
+        expect(subject.complete?("x<-")).to be_falsy
+      end
+      it "correct eval should return true" do 
+        expect(subject.complete?("x<-1")).to be_truthy
+      end
+      it "incorrect eval should raise an ParseError" do
+        expect{subject.eval("x<-")}.to raise_error(RinRuby::ParseError)
+      end
     end
-    it "return false for complete? for incorrect expressions" do
-      expect(subject.complete?("x<-")).to be_falsy
+    context "on assign" do
+      let(:x){rand} 
+      it "should assign correctly" do
+        subject.assign("x",x)
+        expect(subject.pull("x")).to eq(x)
+      end
+      it "should be the same using assign than R#= methods" do
+        subject.assign("x1",x)
+        subject.x2=x
+        expect(subject.pull("x1")).to eq(x)
+        expect(subject.pull("x2")).to eq(x)
+      end
+      it "should raise an ArgumentError error on setter with 0 parameters" do
+        expect{subject.unknown_method=() }.to raise_error(ArgumentError)
+      end
     end
-    it "correct eval should return true" do 
-      expect(subject.complete?("x<-1")).to be_truthy
-    end
-    it "incorrect eval should raise an ParseError" do
-      expect{subject.eval("x<-")}.to raise_error(RinRuby::ParseError)
-    end
-  end
-  context "on assign" do
-    let(:x){rand} 
-    it "should assign correctly" do
-      subject.assign("x",x)
-      expect(subject.pull("x")).to eq(x)
-    end
-    it "should be the same using assign than R#= methods" do
-      subject.assign("x1",x)
-      subject.x2=x
-      expect(subject.pull("x1")).to eq(x)
-      expect(subject.pull("x2")).to eq(x)
-    end
-    it "should raise an ArgumentError error on setter with 0 parameters" do
-      expect{subject.unknown_method=() }.to raise_error(ArgumentError)
-    end
-  end
-  context "on pull" do
-    it "should be the same using pull than R# methods" do
-      x=rand
-      subject.x=x
-      expect(subject.pull("x")).to eq(x)
-      expect(subject.x).to eq(x)
-    end
-    it "should raise an NoMethod error on getter with 1 or more parameters" do
-      expect{subject.unknown_method(1) }.to raise_error(NoMethodError)
-    end
-    
-    it "should pull a String" do
-      subject.eval("x<-'Value'")
-      expect(subject.pull('x')).to eq('Value')
-    end
-    it "should pull an Integer" do
-      subject.eval("x<-1")
-      expect(subject.pull('x')).to eq(1)
-    end
-    it "should pull a Float" do
-      subject.eval("x<-1.5")
-      expect(subject.pull('x')).to eq(1.5)
-    end
-    it "should pull an Array of Numeric" do
-      subject.eval("x<-c(1,2.5,3)")
-      expect(subject.pull('x')).to eq([1,2.5,3])
-    end
-    it "should pull an Array of strings" do
-      subject.eval("x<-c('a','b')")
-      expect(subject.pull('x')).to eq(['a','b'])
-    end
-
-    it "should push a Matrix" do
-      matrix=Matrix::build(100, 200){|i, j| rand} # 100 x 200 matrix
-      expect{subject.assign('x',matrix)}.not_to raise_error
-      rx=subject.x
-      matrix.row_size.times {|i|
-        matrix.column_size.times {|j|
-          expect(matrix[i,j]).to be_within(1e-10).of(rx[i,j])
+    context "on pull" do
+      it "should be the same using pull than R# methods" do
+        x=rand
+        subject.x=x
+        expect(subject.pull("x")).to eq(x)
+        expect(subject.x).to eq(x)
+      end
+      it "should raise an NoMethod error on getter with 1 or more parameters" do
+        expect{subject.unknown_method(1) }.to raise_error(NoMethodError)
+      end
+      
+      it "should pull a String" do
+        subject.eval("x<-'Value'")
+        expect(subject.pull('x')).to eq('Value')
+      end
+      it "should pull an Integer" do
+        subject.eval("x<-1")
+        expect(subject.pull('x')).to eq(1)
+      end
+      it "should pull a Float" do
+        subject.eval("x<-1.5")
+        expect(subject.pull('x')).to eq(1.5)
+      end
+      it "should pull an Array of Numeric" do
+        subject.eval("x<-c(1,2.5,3)")
+        expect(subject.pull('x')).to eq([1,2.5,3])
+      end
+      it "should pull an Array of strings" do
+        subject.eval("x<-c('a','b')")
+        expect(subject.pull('x')).to eq(['a','b'])
+      end
+  
+      it "should push a Matrix" do
+        matrix=Matrix::build(100, 200){|i, j| rand} # 100 x 200 matrix
+        expect{subject.assign('x',matrix)}.not_to raise_error
+        rx=subject.x
+        matrix.row_size.times {|i|
+          matrix.column_size.times {|j|
+            expect(matrix[i,j]).to be_within(1e-10).of(rx[i,j])
+          }
         }
-      }
+      end
     end
   end
   context "on quit" do
@@ -132,4 +123,20 @@ describe RinRuby do
       expect{r.eval("x=1")}.to raise_error(RinRuby::EngineClosed)
     end
   end
+end
+
+describe RinRuby do
+  let(:params){
+    {
+      :echo_enabled => false, 
+      :interactive => false, 
+      :executable => nil, 
+      :port_number => 38500, 
+      :port_width => 1,
+    }
+  }
+  let(:r){
+    RinRuby.new(*([:echo_enabled, :interactive, :executable, :port_number, :port_width].collect{|k| params[k]}))
+  }
+  include_examples 'RinRubyCore'
 end

--- a/spec/rinruby_spec.rb
+++ b/spec/rinruby_spec.rb
@@ -13,6 +13,7 @@ shared_examples 'RinRubyCore' do
     }
   }
   describe "on init" do
+    after{(r.quit rescue nil) if defined?(r)}
     it "should accept parameters as specified on Dahl & Crawford(2009)" do
       expect(r.echo_enabled).to be_falsy
       expect(r.interactive).to be_falsy
@@ -47,7 +48,8 @@ shared_examples 'RinRubyCore' do
     # because a new instance variable will be created for the following examples.
     # For workaround, two-step indirect assignment to a hash created in before(:all) is applied. 
     before(:all){@cached_env = {:r => nil}} # make placeholder
-    subject{@cached_env[:r] ||= r} 
+    subject{@cached_env[:r] ||= r}
+    after(:all){@cached_env[:r].quit rescue nil}
     describe "basic methods" do 
       it {is_expected.to respond_to(:eval)}
       it {is_expected.to respond_to(:assign)}

--- a/spec/rinruby_spec.rb
+++ b/spec/rinruby_spec.rb
@@ -108,16 +108,20 @@ shared_examples 'RinRubyCore' do
         subject.eval("x<-1.5")
         expect(subject.pull('x')).to eq(1.5)
       end
-      it "should pull an Array of Numeric" do
-        subject.eval("x<-c(1,2.5,3)")
-        expect(subject.pull('x')).to eq([1,2.5,3])
-      end
-      it "should pull an Array of strings" do
+      it "should pull an Array of String" do
         subject.eval("x<-c('a','b')")
         expect(subject.pull('x')).to eq(['a','b'])
       end
+      it "should pull an Array of Integer" do
+        subject.eval("x<-c(1,2.5,3)")
+        expect(subject.pull('x')).to eq([1,2.5,3])
+      end
+      it "should pull an Array of Float" do
+        subject.eval("x<-c(1.1,2.2,5,3)")
+        expect(subject.pull('x')).to eq([1.1,2.2,5.0,3.0])
+      end
 
-      it "should push a Matrix" do
+      it "should pull a Matrix" do
         matrix=Matrix::build(100, 200){|i, j| rand} # 100 x 200 matrix
         expect{subject.assign('x',matrix)}.not_to raise_error
         rx=subject.x

--- a/spec/rinruby_spec.rb
+++ b/spec/rinruby_spec.rb
@@ -3,15 +3,19 @@ require 'rinruby'
 puts "RinRuby #{RinRuby::VERSION} specification"
 
 shared_examples 'RinRubyCore' do
-  #before{
-  #  subject.echo(false)
-  #}
+  let(:params){
+    {
+      :echo_enabled => false, 
+      :interactive => false, 
+      :executable => nil, 
+      :port_number => 38500,
+      :port_width => 1000,
+    }
+  }
   describe "on init" do
     it "should accept parameters as specified on Dahl & Crawford(2009)" do
       expect(r.echo_enabled).to be_falsy
       expect(r.interactive).to be_falsy
-      expect(r.port_number).to eq(params[:port_number])
-      expect(r.port_width).to eq(params[:port_width])
       case r.instance_variable_get(:@platform)
       when /^windows/ then
         expect(r.executable).to match(/Rterm\.exe["']?$/)
@@ -20,7 +24,7 @@ shared_examples 'RinRubyCore' do
       end      
     end
     it "should accept custom :port_number" do
-      params.merge!(:port_number => 38442+rand(3))
+      params.merge!(:port_number => 38442+rand(3), :port_width => 1)
       expect(r.port_number).to eq(params[:port_number])
     end
     it "should accept custom :port_width" do
@@ -32,9 +36,8 @@ shared_examples 'RinRubyCore' do
     end
   end
   describe "R interface" do
-    subject{
-      R_INSTANCE ||= r
-    }
+    before(:all){@cached_env = {:r => nil}} # make placeholder
+    subject{@cached_env[:r] ||= r}
     describe "basic methods" do 
       it {is_expected.to respond_to(:eval)}
       it {is_expected.to respond_to(:assign)}
@@ -126,15 +129,6 @@ shared_examples 'RinRubyCore' do
 end
 
 describe RinRuby do
-  let(:params){
-    {
-      :echo_enabled => false, 
-      :interactive => false, 
-      :executable => nil, 
-      :port_number => 38500, 
-      :port_width => 1,
-    }
-  }
   let(:r){
     RinRuby.new(*([:echo_enabled, :interactive, :executable, :port_number, :port_width].collect{|k| params[k]}))
   }

--- a/spec/rinruby_spec.rb
+++ b/spec/rinruby_spec.rb
@@ -3,19 +3,23 @@ require 'rinruby'
 puts "RinRuby #{RinRuby::VERSION} specification"
 
 describe RinRuby do
+  let(:params){
+    {
+      :echo_enabled => false, 
+      :interactive => false, 
+      :executable => nil, 
+      :port_number => 38500, 
+      :port_width => 1,
+    }
+  }
+  let(:r){
+    RinRuby.new(*([:echo_enabled, :interactive, :executable, :port_number, :port_width].collect{|k| params[k]}))
+  }
+  subject{R}
+  before do
+    subject.echo(false)
+  end
   describe "on init" do
-    let(:params){
-      {
-        :echo_enabled => false, 
-        :interactive => false, 
-        :executable => nil, 
-        :port_number => 38500, 
-        :port_width => 1,
-      }
-    }
-    let(:r){
-      RinRuby.new(*([:echo_enabled, :interactive, :executable, :port_number, :port_width].collect{|k| params[k]}))
-    }
     it "should accept parameters as specified on Dahl & Crawford(2009)" do
       expect(r.echo_enabled).to be_falsy
       expect(r.interactive).to be_falsy
@@ -40,11 +44,7 @@ describe RinRuby do
       }
     end
   end
-  before do
-    R.echo(false)
-  end
-  subject {R}
-  context "basic methods" do 
+  describe "basic methods" do 
     it {is_expected.to respond_to(:eval)}
     it {is_expected.to respond_to(:quit)}
     it {is_expected.to respond_to(:assign)}
@@ -52,81 +52,78 @@ describe RinRuby do
     it {is_expected.to respond_to(:quit)}
     it {is_expected.to respond_to(:echo)}
     it "return correct values for complete?" do
-      expect(R.eval("x<-1")).to be_truthy
+      expect(subject.eval("x<-1")).to be_truthy
     end
     it "return false for complete? for incorrect expressions" do
-      expect(R.complete?("x<-")).to be_falsy
+      expect(subject.complete?("x<-")).to be_falsy
     end
     it "correct eval should return true" do 
-      expect(R.complete?("x<-1")).to be_truthy
+      expect(subject.complete?("x<-1")).to be_truthy
     end
     it "incorrect eval should raise an ParseError" do
-      expect{R.eval("x<-")}.to raise_error(RinRuby::ParseError)
+      expect{subject.eval("x<-")}.to raise_error(RinRuby::ParseError)
     end
   end
-  context "on assing" do
+  context "on assign" do
     let(:x){rand} 
     it "should assign correctly" do
-      R.assign("x",x)
-      expect(R.pull("x")).to eq(x)
+      subject.assign("x",x)
+      expect(subject.pull("x")).to eq(x)
     end
     it "should be the same using assign than R#= methods" do
-      R.assign("x1",x)
-      R.x2=x
-      expect(R.pull("x1")).to eq(x)
-      expect(R.pull("x2")).to eq(x)
+      subject.assign("x1",x)
+      subject.x2=x
+      expect(subject.pull("x1")).to eq(x)
+      expect(subject.pull("x2")).to eq(x)
     end
     it "should raise an ArgumentError error on setter with 0 parameters" do
-      expect{R.unknown_method=() }.to raise_error(ArgumentError)
+      expect{subject.unknown_method=() }.to raise_error(ArgumentError)
     end
   end
   context "on pull" do
     it "should be the same using pull than R# methods" do
       x=rand
-      R.x=x
-      expect(R.pull("x")).to eq(x)
-      expect(R.x).to eq(x)
+      subject.x=x
+      expect(subject.pull("x")).to eq(x)
+      expect(subject.x).to eq(x)
     end
     it "should raise an NoMethod error on getter with 1 or more parameters" do
-      expect{R.unknown_method(1) }.to raise_error(NoMethodError)
+      expect{subject.unknown_method(1) }.to raise_error(NoMethodError)
     end
     
     it "should pull a String" do
-      R.eval("x<-'Value'")
-      expect(R.pull('x')).to eq('Value')
+      subject.eval("x<-'Value'")
+      expect(subject.pull('x')).to eq('Value')
     end
     it "should pull an Integer" do
-      R.eval("x<-1")
-      expect(R.pull('x')).to eq(1)
+      subject.eval("x<-1")
+      expect(subject.pull('x')).to eq(1)
     end
     it "should pull a Float" do
-      R.eval("x<-1.5")
-      expect(R.pull('x')).to eq(1.5)
+      subject.eval("x<-1.5")
+      expect(subject.pull('x')).to eq(1.5)
     end
     it "should pull an Array of Numeric" do
-      R.eval("x<-c(1,2.5,3)")
-      expect(R.pull('x')).to eq([1,2.5,3])
+      subject.eval("x<-c(1,2.5,3)")
+      expect(subject.pull('x')).to eq([1,2.5,3])
     end
     it "should pull an Array of strings" do
-      R.eval("x<-c('a','b')")
-      expect(R.pull('x')).to eq(['a','b'])
+      subject.eval("x<-c('a','b')")
+      expect(subject.pull('x')).to eq(['a','b'])
     end
 
     it "should push a Matrix" do
       matrix=Matrix::build(100, 200){|i, j| rand} # 100 x 200 matrix
-      expect{R.assign('x',matrix)}.not_to raise_error
-      rx=R.x
+      expect{subject.assign('x',matrix)}.not_to raise_error
+      rx=subject.x
       matrix.row_size.times {|i|
         matrix.column_size.times {|j|
           expect(matrix[i,j]).to be_within(1e-10).of(rx[i,j])
         }
       }
     end
-    
   end
-
   context "on quit" do
-    let(:r){RinRuby.new(:echo=>false)}
     it "return true" do
       expect(r.quit).to be_truthy
     end

--- a/spec/rinruby_without_r_constant_spec.rb
+++ b/spec/rinruby_without_r_constant_spec.rb
@@ -2,15 +2,6 @@ require File.expand_path(File.dirname(__FILE__) + '/spec_helper')
 require 'rinruby_without_r_constant'
 
 describe RinRubyWithoutRConstant do
-  let(:params){
-    {
-      :echo_enabled => false, 
-      :interactive => false, 
-      :executable => nil, 
-      :port_number => 38525, 
-      :port_width => 1,
-    }
-  }
   let(:r){
     RinRubyWithoutRConstant.new(*([:echo_enabled, :interactive, :executable, :port_number, :port_width].collect{|k| params[k]}))
   }

--- a/spec/rinruby_without_r_constant_spec.rb
+++ b/spec/rinruby_without_r_constant_spec.rb
@@ -2,149 +2,17 @@ require File.expand_path(File.dirname(__FILE__) + '/spec_helper')
 require 'rinruby_without_r_constant'
 
 describe RinRubyWithoutRConstant do
-  describe "on init" do
-    it "should accept parameters as specified on Dahl & Crawford(2009)" do
-      
-      platform = case RUBY_PLATFORM
-      when /mswin/ then 'windows'
-      when /mingw/ then 'windows'
-      when /bccwin/ then 'windows'
-      else 
-        "other"
-      end
-      if platform=='windows'
-        skip("Difficult to test without specific location of R executable on Windows")
-      else      
-      R.quit
-      r=RinRubyWithoutRConstant.new(false, false, "R", 38525, 1)
-
-      expect(r.echo_enabled).to be false
-      r.interactive.should be false
-      r.executable.should=="R"
-      r.port_number.should==38525
-      r.port_width.should==1
-      end
-    end
-    it "should accept :echo and :interactive parameters" do
-      r=RinRubyWithoutRConstant.new(:echo=>false, :interactive=>false)
-      r.echo_enabled.should be false
-      r.interactive.should be false
-      
-    end
-    it "should accept :port_number" do
-      port=38542+rand(3)
-      r=RinRubyWithoutRConstant.new(:port_number=>port,:port_width=>1)
-      r.port_number.should==port
-      r.quit
-    end
-    it "should accept :port_width" do
-      port=38542
-      port_width=rand(10)+1
-      r=RinRubyWithoutRConstant.new(:port=>port, :port_width=>port_width)
-      expect(r.port_width).to be == port_width
-      r.port_number.should satisfy {|v| v>=port and v < port+port_width}
-    end
-  end
-  before do
-    @rr = RinRubyWithoutRConstant.new
-    @rr.echo(false)
-  end
-  subject {@rr}
-  context "basic methods" do 
-    it {should respond_to :eval}
-    it {should respond_to :quit}
-    it {should respond_to :assign}
-    it {should respond_to :pull}
-    it {should respond_to :quit}
-    it {should respond_to :echo}
-    it "return correct values for complete?" do
-      @rr.eval("x<-1").should be true
-    end
-    it "return false for complete? for incorrect expressions" do
-      @rr.complete?("x<-").should be false
-    end
-    it "correct eval should return true" do 
-      @rr.complete?("x<-1").should be true
-    end
-    it "incorrect eval should raise an ParseError" do
-      lambda {@rr.eval("x<-")}.should raise_error(RinRubyWithoutRConstant::ParseError)
-    end
-  end
-  context "on assing" do 
-    it "should assign correctly" do
-      x=rand
-      @rr.assign("x",x)
-      @rr.pull("x").should==x
-    end
-    it "should be the same using assign than R#= methods" do
-      x=rand
-      @rr.assign("x1",x)
-      @rr.x2=x
-      @rr.pull("x1").should==x
-      @rr.pull("x2").should==x
-    end
-    it "should raise an ArgumentError error on setter with 0 parameters" do
-      lambda {@rr.unknown_method=() }.should raise_error(ArgumentError)
-    end
-    
-  end
-  context "on pull" do
-    it "should be the same using pull than R# methods" do
-      x=rand
-      @rr.x=x
-      @rr.pull("x").should==x
-      @rr.x.should==x
-    end
-    it "should raise an NoMethod error on getter with 1 or more parameters" do
-      lambda {@rr.unknown_method(1) }.should raise_error(NoMethodError)
-    end
-    
-    it "should pull a String" do
-      @rr.eval("x<-'Value'")
-      @rr.pull('x').should=='Value'
-    end
-    it "should pull an Integer" do
-      @rr.eval("x<-1")
-      @rr.pull('x').should==1
-    end
-    it "should pull a Float" do
-      @rr.eval("x<-1.5")
-      @rr.pull('x').should==1.5
-    end
-    it "should pull an Array of Numeric" do
-      @rr.eval("x<-c(1,2.5,3)")
-      @rr.pull('x').should==[1,2.5,3]
-    end
-    it "should pull an Array of strings" do
-      @rr.eval("x<-c('a','b')")
-      @rr.pull('x').should==['a','b']
-    end
-
-    it "should push a Matrix" do
-      matrix=Matrix::build(100, 200){|i, j| rand} # 100 x 200 matrix
-      lambda {@rr.assign('x',matrix)}.should_not raise_error
-      rx=@rr.x
-      matrix.row_size.times {|i|
-        matrix.column_size.times {|j|
-          matrix[i,j].should be_within(1e-10).of(rx[i,j])
-        }
-      }
-    end
-    
-  end
-
-  context "on quit" do
-    before(:each) do
-      @r=RinRubyWithoutRConstant.new(:echo=>false)
-    end
-    it "return true" do
-      @r.quit.should be true
-    end
-    it "returns an error if used again" do
-      @r.quit
-      lambda {@r.eval("x=1")}.should raise_error(RinRubyWithoutRConstant::EngineClosed)
-    end
-  end
-  
-
+  let(:params){
+    {
+      :echo_enabled => false, 
+      :interactive => false, 
+      :executable => nil, 
+      :port_number => 38525, 
+      :port_width => 1,
+    }
+  }
+  let(:r){
+    RinRubyWithoutRConstant.new(*([:echo_enabled, :interactive, :executable, :port_number, :port_width].collect{|k| params[k]}))
+  }
+  include_examples 'RinRubyCore'
 end


### PR DESCRIPTION
* Remove redundant test code for RinRubyWithoutRConstant, which is currently a subclass of RinRuby by using RinRuby test code with [RSpec's shared examples feature](https://relishapp.com/rspec/rspec-core/docs/example-groups/shared-examples).
* ["should" will be deprecated, and "expect" is its alternative](https://github.com/rspec/rspec-expectations/blob/master/Should.md).