### PR TITLE
Ruby nil and NA support

### DIFF
--- a/lib/rinruby.rb
+++ b/lib/rinruby.rb
@@ -660,7 +660,7 @@ def initialize(*args)
           when false; 0
           when nil; RinRuby_NA_R_Integer
           else; break false
-          end
+          end rescue break false # combination of Float::NAN and "case" flow invokes FloatDomainError
         }
       value = value_b
       RinRuby_Type_Boolean

--- a/lib/rinruby.rb
+++ b/lib/rinruby.rb
@@ -599,15 +599,17 @@ def initialize(*args)
             as.integer(#{RinRuby_Type_Double}),
             as.integer(length(var)),
             var)
-      } else if ( is.character(var) && ( length(var) == 1 ) ) {
-        #{RinRuby_Env}$write(con, 
-            as.integer(#{RinRuby_Type_String}),
-            as.integer(nchar(var)),
-            var)
-      } else if ( is.character(var) && ( length(var) > 1 ) ) {
-        #{RinRuby_Env}$write(con, 
-            as.integer(#{RinRuby_Type_String_Array}),
-            as.integer(length(var)))
+      } else if ( is.character(var) ) {
+        if( length(var) == 1 ){
+          #{RinRuby_Env}$write(con, 
+              as.integer(#{RinRuby_Type_String}),
+              as.integer(nchar(var)),
+              var)
+        }else{
+          #{RinRuby_Env}$write(con, 
+              as.integer(#{RinRuby_Type_String_Array}),
+              as.integer(length(var)))
+        }
       } else {
         #{RinRuby_Env}$write(con, as.integer(#{RinRuby_Type_Unknown}))
       }

--- a/lib/rinruby.rb
+++ b/lib/rinruby.rb
@@ -601,10 +601,13 @@ def initialize(*args)
             var)
       } else if ( is.character(var) ) {
         if( length(var) == 1 ){
-          #{RinRuby_Env}$write(con, 
-              as.integer(#{RinRuby_Type_String}),
-              as.integer(nchar(var)),
-              var)
+          args <- list(con, as.integer(#{RinRuby_Type_String}))
+          if( is.na(var) ){
+            args <- c(args, as.integer(NA))
+          }else{
+            args <- c(args, as.integer(nchar(var)), var)
+          }
+          do.call(#{RinRuby_Env}$write, args)
         }else{
           #{RinRuby_Env}$write(con, 
               as.integer(#{RinRuby_Type_String_Array}),
@@ -733,9 +736,8 @@ def initialize(*args)
         result = socket.read(8 * length).unpack("D#{length}")
         (!singletons) && (length == 1) ? result[0] : result 
       when RinRuby_Type_String
-        result = socket.read(length)
-        socket.read(1) # zero-terminated string
-        result
+        # negative length means NA, and "+ 1" for zero-terminated string
+        (length >= 0) ? socket.read(length + 1)[0..-2] : nil
       when RinRuby_Type_String_Array
         Array.new(length){|i|
           pull_proc.call("#{var}[#{i+1}]", socket)

--- a/lib/rinruby.rb
+++ b/lib/rinruby.rb
@@ -658,14 +658,18 @@ def initialize(*args)
           case x
           when true; 1
           when false; 0
+          when nil; RinRuby_NA_R_Integer
           else; break false
           end
         }
       value = value_b
       RinRuby_Type_Boolean
-    elsif value.all?{|x|
-          x.kind_of?(Integer) && (x >= RinRuby_Min_R_Integer) && (x <= RinRuby_Max_R_Integer)
+    elsif value_i = value.collect{|x|
+          next RinRuby_NA_R_Integer if x == nil
+          next x if x.kind_of?(Integer) && (x >= RinRuby_Min_R_Integer) && (x <= RinRuby_Max_R_Integer)
+          break false
         }
+      value = value_i
       RinRuby_Type_Integer
     elsif value_f = value.collect{|x|
           break false unless x.kind_of?(Numeric)
@@ -714,10 +718,14 @@ def initialize(*args)
   
       case type
       when RinRuby_Type_Boolean
-        result = socket.read(4 * length).unpack("l#{length}").collect{|v| v > 0}
+        result = socket.read(4 * length).unpack("l#{length}").collect{|v|
+          (v == RinRuby_NA_R_Integer) ? nil : (v > 0)
+        }
         (!singletons) && (length == 1) ? result[0] : result
       when RinRuby_Type_Integer
-        result = socket.read(4 * length).unpack("l#{length}")
+        result = socket.read(4 * length).unpack("l#{length}").collect{|v|
+          (v == RinRuby_NA_R_Integer) ? nil : v
+        }
         (!singletons) && (length == 1) ? result[0] : result
       when RinRuby_Type_Double
         result = socket.read(8 * length).unpack("D#{length}")

--- a/lib/rinruby.rb
+++ b/lib/rinruby.rb
@@ -734,6 +734,12 @@ def initialize(*args)
         (!singletons) && (length == 1) ? result[0] : result
       when RinRuby_Type_Double
         result = socket.read(8 * length).unpack("D#{length}")
+        
+        # check NA; caution is.na(c(NA, NaN)) => c(T, T), is.nan(c(NA, NaN)) => c(F, T) 
+        @writer.puts "#{RinRuby_Env}$pull(which(is.na(#{var} & (!is.nan(#{var})))) - 1L)"
+        na_indices = socket.read(8).unpack('ll')[1]
+        socket.read(4 * na_indices).unpack("l#{na_indices}").each{|i| result[i] = nil}
+        
         (!singletons) && (length == 1) ? result[0] : result 
       when RinRuby_Type_String
         # negative length means NA, and "+ 1" for zero-terminated string

--- a/spec/rinruby_spec.rb
+++ b/spec/rinruby_spec.rb
@@ -92,7 +92,7 @@ shared_examples 'RinRubyCore' do
         }
       end
       it "should pull a Logical" do
-        {:T => true, :F => false}.each{|k, v|
+        {:T => true, :F => false, :NA => nil}.each{|k, v|
           subject.eval("x<-#{k}")
           expect(subject.pull('x')).to eql(v)
         }
@@ -102,8 +102,8 @@ shared_examples 'RinRubyCore' do
         expect(subject.pull('x')).to eql(['a','b'])
       end
       it "should pull an Array of Integer" do
-        subject.eval("x<-c(1L,2L,-5L,-3L)")
-        expect(subject.pull('x')).to eql([1,2,-5,-3])
+        subject.eval("x<-c(1L,2L,-5L,-3L,NA)")
+        expect(subject.pull('x')).to eql([1,2,-5,-3,nil])
       end
       it "should pull an Array of Float" do
         subject.eval("x<-c(1.1,2.2,5,3)")
@@ -112,8 +112,8 @@ shared_examples 'RinRubyCore' do
         expect(subject.pull('x')).to eql([1.0,2.0,5.0,3.0])
       end
       it "should pull an Array of Logical" do
-        subject.eval("x<-c(T, F)")
-        expect(subject.pull('x')).to eql([true, false])
+        subject.eval("x<-c(T, F, NA)")
+        expect(subject.pull('x')).to eql([true, false, nil])
       end
 
       it "should pull a Matrix" do
@@ -168,7 +168,7 @@ shared_examples 'RinRubyCore' do
         }
       end
       it "should assign a Logical" do
-        [true, false].each{|x|
+        [true, false, nil].each{|x|
           subject.assign("x", x)
           expect(subject.pull('x')).to eql(x)
         }
@@ -179,7 +179,7 @@ shared_examples 'RinRubyCore' do
         expect(subject.pull('x')).to eql(x)
       end
       it "should assign an Array of Integer" do
-        x = [1, 2, -5, -3]
+        x = [1, 2, -5, -3, nil]
         subject.assign("x", x)
         expect(subject.pull('x')).to eql(x)
       end
@@ -188,7 +188,7 @@ shared_examples 'RinRubyCore' do
         expect(subject.pull('x')).to eql([1.1,2.2,5.0,3.0])
       end
       it "should assign an Array of Logical" do
-        x = [true, false]
+        x = [true, false, nil]
         subject.assign("x", x)
         expect(subject.pull('x')).to eql(x)
       end

--- a/spec/rinruby_spec.rb
+++ b/spec/rinruby_spec.rb
@@ -90,6 +90,8 @@ shared_examples 'RinRubyCore' do
           subject.eval("x<-#{v}")
           expect(subject.pull('x')).to eql(v.to_f)
         }
+        subject.eval("x<-NaN")
+        expect(subject.pull('x').nan?).to be_truthy
       end
       it "should pull a Logical" do
         {:T => true, :F => false, :NA => nil}.each{|k, v|
@@ -106,10 +108,12 @@ shared_examples 'RinRubyCore' do
         expect(subject.pull('x')).to eql([1,2,-5,-3,nil])
       end
       it "should pull an Array of Float" do
-        subject.eval("x<-c(1.1,2.2,5,3)")
-        expect(subject.pull('x')).to eql([1.1,2.2,5.0,3.0])
-        subject.eval("x<-c(1L,2L,5L,3.0)") # numeric vector 
-        expect(subject.pull('x')).to eql([1.0,2.0,5.0,3.0])
+        subject.eval("x<-c(1.1,2.2,5,3,NaN)") # auto-conversion to numeric vector
+        expect(subject.pull('x')[0..-2]).to eql([1.1,2.2,5.0,3.0])
+        expect(subject.pull('x')[-1].nan?).to be_truthy
+        subject.eval("x<-c(1L,2L,5L,3.0,NaN)") # auto-conversion to numeric vector 
+        expect(subject.pull('x')[0..-2]).to eql([1.0,2.0,5.0,3.0])
+        expect(subject.pull('x')[-1].nan?).to be_truthy
       end
       it "should pull an Array of Logical" do
         subject.eval("x<-c(T, F, NA)")
@@ -166,6 +170,8 @@ shared_examples 'RinRubyCore' do
           subject.assign("x", x)
           expect(subject.pull('x')).to eql(x.to_f)
         }
+        subject.assign("x", Float::NAN)
+        expect(subject.pull('x').nan?).to be_truthy
       end
       it "should assign a Logical" do
         [true, false, nil].each{|x|
@@ -184,8 +190,9 @@ shared_examples 'RinRubyCore' do
         expect(subject.pull('x')).to eql(x)
       end
       it "should assign an Array of Float" do
-        subject.assign("x", [1.1, 2.2, 5, 3])
-        expect(subject.pull('x')).to eql([1.1,2.2,5.0,3.0])
+        subject.assign("x", [1.1, 2.2, 5, 3, Float::NAN])
+        expect(subject.pull('x')[0..-2]).to eql([1.1,2.2,5.0,3.0])
+        expect(subject.pull('x')[-1].nan?).to be_truthy
       end
       it "should assign an Array of Logical" do
         x = [true, false, nil]

--- a/spec/rinruby_spec.rb
+++ b/spec/rinruby_spec.rb
@@ -238,11 +238,12 @@ shared_examples 'RinRubyCore' do
           [ # float matrix
             proc{rand},
             proc{|a, b|
+              threshold = Float::EPSILON * 10
               expect(a.row_size).to eql(b.row_size)
               expect(a.column_size).to eql(b.column_size)
               a.row_size.times{|i|
                 a.column_size.times{|j|
-                  expect(a[i,j]).to be_within(Float::EPSILON).of(b[i,j])
+                  expect(a[i,j]).to be_within(threshold).of(b[i,j])
                 }
               }
             },
@@ -250,12 +251,13 @@ shared_examples 'RinRubyCore' do
           [ # float matrix with NA
             proc{v = rand; v > 0.5 ? nil : v},
             proc{|a, b|
+              threshold = Float::EPSILON * 10
               expect(a.row_size).to eql(b.row_size)
               expect(a.column_size).to eql(b.column_size)
               a.row_size.times{|i|
                 a.column_size.times{|j|
                   if b[i,j].kind_of?(Numeric) then
-                    expect(a[i,j]).to be_within(Float::EPSILON).of(b[i,j])
+                    expect(a[i,j]).to be_within(threshold).of(b[i,j])
                   else
                     expect(a[i,j]).to eql(nil)
                   end

--- a/spec/rinruby_spec.rb
+++ b/spec/rinruby_spec.rb
@@ -72,8 +72,12 @@ shared_examples 'RinRubyCore' do
     
     context "on pull" do
       it "should pull a String" do
-        subject.eval("x<-'Value'")
-        expect(subject.pull('x')).to eql('Value')
+        ['Value', ''].each{|v| # normal string and zero-length string
+          subject.eval("x<-'#{v}'")
+          expect(subject.pull('x')).to eql(v)
+        }
+        subject.eval("x<-as.character(NA)")
+        expect(subject.pull('x')).to eql(nil)
       end
       it "should pull an Integer" do
         [0x12345678, -0x12345678].each{|v| # for check endian, and range
@@ -101,7 +105,7 @@ shared_examples 'RinRubyCore' do
       end
       it "should pull an Array of String" do
         {
-          "c('a','b')" => ['a','b'], 
+          "c('a','b','',NA)" => ['a','b','',nil],
           "as.character(NULL)" => [],
         }.each{|k, v|
           subject.eval("x<-#{k}")

--- a/spec/rinruby_spec.rb
+++ b/spec/rinruby_spec.rb
@@ -96,6 +96,8 @@ shared_examples 'RinRubyCore' do
         }
         subject.eval("x<-NaN")
         expect(subject.pull('x').nan?).to be_truthy
+        subject.eval("x<-as.numeric(NA)")
+        expect(subject.pull('x')).to eql(nil)
       end
       it "should pull a Logical" do
         {:T => true, :F => false, :NA => nil}.each{|k, v|
@@ -122,12 +124,12 @@ shared_examples 'RinRubyCore' do
         }
       end
       it "should pull an Array of Float" do
-        subject.eval("x<-c(1.1,2.2,5,3,NaN)") # auto-conversion to numeric vector
-        expect(subject.pull('x')[0..-2]).to eql([1.1,2.2,5.0,3.0])
+        subject.eval("x<-c(1.1,2.2,5,3,NA,NaN)") # auto-conversion to numeric vector
+        expect(subject.pull('x')[0..-2]).to eql([1.1,2.2,5.0,3.0,nil])
         expect(subject.pull('x')[-1].nan?).to be_truthy
         
-        subject.eval("x<-c(1L,2L,5L,3.0,NaN)") # auto-conversion to numeric vector 
-        expect(subject.pull('x')[0..-2]).to eql([1.0,2.0,5.0,3.0])
+        subject.eval("x<-c(1L,2L,5L,3.0,NA,NaN)") # auto-conversion to numeric vector 
+        expect(subject.pull('x')[0..-2]).to eql([1.0,2.0,5.0,3.0,nil])
         expect(subject.pull('x')[-1].nan?).to be_truthy
         
         subject.eval("x<-as.numeric(NULL)")

--- a/spec/rinruby_spec.rb
+++ b/spec/rinruby_spec.rb
@@ -100,24 +100,43 @@ shared_examples 'RinRubyCore' do
         }
       end
       it "should pull an Array of String" do
-        subject.eval("x<-c('a','b')")
-        expect(subject.pull('x')).to eql(['a','b'])
+        {
+          "c('a','b')" => ['a','b'], 
+          "as.character(NULL)" => [],
+        }.each{|k, v|
+          subject.eval("x<-#{k}")
+          expect(subject.pull('x')).to eql(v)
+        }
       end
       it "should pull an Array of Integer" do
-        subject.eval("x<-c(1L,2L,-5L,-3L,NA)")
-        expect(subject.pull('x')).to eql([1,2,-5,-3,nil])
+        {
+          "c(1L,2L,-5L,-3L,NA)" => [1,2,-5,-3,nil], 
+          "as.integer(NULL)" => [],
+        }.each{|k, v|
+          subject.eval("x<-#{k}")
+          expect(subject.pull('x')).to eql(v)
+        }
       end
       it "should pull an Array of Float" do
         subject.eval("x<-c(1.1,2.2,5,3,NaN)") # auto-conversion to numeric vector
         expect(subject.pull('x')[0..-2]).to eql([1.1,2.2,5.0,3.0])
         expect(subject.pull('x')[-1].nan?).to be_truthy
+        
         subject.eval("x<-c(1L,2L,5L,3.0,NaN)") # auto-conversion to numeric vector 
         expect(subject.pull('x')[0..-2]).to eql([1.0,2.0,5.0,3.0])
         expect(subject.pull('x')[-1].nan?).to be_truthy
+        
+        subject.eval("x<-as.numeric(NULL)")
+        expect(subject.pull('x')).to eql([])
       end
       it "should pull an Array of Logical" do
-        subject.eval("x<-c(T, F, NA)")
-        expect(subject.pull('x')).to eql([true, false, nil])
+        {
+          "c(T, F, NA)" => [true, false, nil], 
+          "as.logical(NULL)" => [],
+        }.each{|k, v|
+          subject.eval("x<-#{k}")
+          expect(subject.pull('x')).to eql(v)
+        }
       end
 
       it "should pull a Matrix" do


### PR DESCRIPTION
* Ruby nil is interpreted as R NA for assign, vice verse for pull.
* R NaN and NA are differently treated, which correspond to Ruby Float::NAN and nil, respectively.
* If there is no nil in Ruby value, conversion speed may not be spoiled.