### PR TITLE
AppVeyor Windows CI

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,5 +1,8 @@
 version: 1.0.{build}.{branch}
 
+cache:
+  - vendor/bundle
+
 environment:
   matrix:
     - ruby_version: 25
@@ -13,7 +16,11 @@ environment:
 
 install:
   - set PATH=C:\Ruby%ruby_version%\bin;%PATH%
-  - bundle install
+  - cmd: >-
+      bundle config --local path vendor/bundle
+
+      bundle install
+
   - cmd: >-
       SET r_installer=C:\R-%r_version%-win.exe
 

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,0 +1,36 @@
+version: 1.0.{build}.{branch}
+
+environment:
+  matrix:
+    - ruby_version: 25
+      r_version: 3.5.1
+    - ruby_version: 25
+      r_version: 3.2.5
+    - ruby_version: 24
+      r_version: 3.5.1
+    - ruby_version: 21
+      r_version: 3.5.1
+
+install:
+  - set PATH=C:\Ruby%ruby_version%\bin;%PATH%
+  - bundle install
+  - cmd: >-
+      SET r_installer=C:\R-%r_version%-win.exe
+
+      echo R installer is %r_installer%
+
+      SET r_archive=https://cran.r-project.org/bin/windows/base
+
+      appveyor DownloadFile %r_archive%/R-%r_version%-win.exe -FileName %r_installer% || appveyor DownloadFile %r_archive%/old/%r_version%/R-%r_version%-win.exe -FileName %r_installer%
+
+      echo Installing %r_installer% ... && %r_installer% /SILENT /DIR="C:\R-%r_version%"
+
+build: off
+
+before_test:
+  - ruby -v
+  - gem -v
+  - bundle -v
+
+test_script:
+  - bundle exec rspec

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -5,6 +5,8 @@ cache:
 
 environment:
   matrix:
+    - jruby_version: 9.2.0.0
+      r_version: 3.5.1
     - ruby_version: 25
       r_version: 3.5.1
     - ruby_version: 25
@@ -15,8 +17,21 @@ environment:
       r_version: 3.5.1
 
 install:
+  - cmd: >-
+      if not defined jruby_version set JRUBY_PROCESS=rem
+
+      %JRUBY_PROCESS% appveyor DownloadFile https://repo1.maven.org/maven2/org/jruby/jruby-dist/%jruby_version%/jruby-dist-%jruby_version%-bin.zip
+
+      %JRUBY_PROCESS% 7z x jruby-dist-%jruby_version%-bin.zip -y -o"C:\Ruby"
+
+      %JRUBY_PROCESS% set ruby_version="\jruby-%jruby_version%"
+      
   - set PATH=C:\Ruby%ruby_version%\bin;%PATH%
   - cmd: >-
+      %JRUBY_PROCESS% gem update --system
+
+      %JRUBY_PROCESS% gem install bundler
+
       bundle config --local path vendor/bundle
 
       bundle install
@@ -35,12 +50,12 @@ install:
 build: off
 
 before_test:
-  - ruby -v
+  - if defined jruby_version ( jruby -v ) else ( ruby -v )
   - gem -v
   - bundle -v
 
 test_script:
-  - bundle exec rspec
+  - if defined jruby_version ( bundle exec rspec %CD%\spec ) else ( bundle exec rspec )
 
 after_test:
   - cmd: >-

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -34,3 +34,13 @@ before_test:
 
 test_script:
   - bundle exec rspec
+
+after_test:
+  - cmd: >-
+      type nul > %APPVEYOR_REPO_COMMIT%.commit
+
+      7z a coverage.%APPVEYOR_REPO_BRANCH%.zip %APPVEYOR_BUILD_FOLDER%\coverage %APPVEYOR_REPO_COMMIT%.commit
+
+artifacts:
+  - path: coverage.*.zip
+    name: Coverage measured by simplecov


### PR DESCRIPTION
This PR turns on CI on Windows with [AppVeyor](https://www.appveyor.com/) after AppVeyor setup.
The example test is https://ci.appveyor.com/project/fenrir-naru/rinruby/build/job/82wj1g9h9eynj3lf .
You can get [build status badges](https://www.appveyor.com/docs/status-badges/) from [Settings]-[Badges].