### PR TITLE
Fix assign with "<-" instead of "<<-"

### DIFF
--- a/lib/rinruby.rb
+++ b/lib/rinruby.rb
@@ -519,12 +519,12 @@ class RinRuby
       invisible(function(){eval(parsed, env=globalenv())}) # return evaluating function
     }
     #{RinRuby_Env}$assignable <- function(var) {
-      parsed <- try(parse(text=paste0(var, ' <<- v')), silent=TRUE)
+      parsed <- try(parse(text=paste0('substitute(', var, ' <- v)')), silent=TRUE)
       is_invalid <- inherits(parsed, "try-error") || (length(parsed) != 1L)
       #{RinRuby_Env}$session.write(function(write){
         write(ifelse(is_invalid, 0L, 1L))
       })
-      invisible(function(v){eval(parsed)}) # return assigning function
+      invisible(function(v){eval(eval(parsed), envir=globalenv())}) # return assigning function
     }
     EOF
   end


### PR DESCRIPTION
This commit fixes a problem raised when values are tried to be assigned to a reserved name, for example "t" (transpose function). 
Normally "t <-1" is acceptable, because "t" will be newly generated in the top environment overriding the base environment, however "t <<- 1" raises an error.
It is natural to use "<-" instead of "<<-", for normal assignment.