### PR TITLE
Better eval sigint handling

### DIFF
--- a/lib/rinruby.rb
+++ b/lib/rinruby.rb
@@ -260,10 +260,10 @@ class RinRuby
       if cmds[-1] then # the last "nil" input suspend current stack
         break if /^\s*exit\s*\(\s*\)\s*$/ =~ cmds[0]
         begin
-          eval_res = false
-          next unless if_complete(cmds){|fun|
-            eval_res = eval_engine("#{fun}()")
+          completed, eval_res = if_complete(cmds){|fun|
+            [true, eval_engine("#{fun}()")]
           }
+          next unless completed
           break unless eval_res
         rescue ParseError => e
           puts e.message

--- a/spec/rinruby_spec.rb
+++ b/spec/rinruby_spec.rb
@@ -366,6 +366,7 @@ shared_examples 'RinRubyCore' do
         input.shift
       } if defined?(Readline)
       allow(r).to receive(:gets){input.shift}
+      r.echo(true, true)
     }
     it "should exit with exit() input" do
       ['exit()', ' exit ( ) '].each{|str|
@@ -392,6 +393,17 @@ shared_examples 'RinRubyCore' do
       ].each{|src|
         input.replace(src + ['exit()'])
         expect{r.prompt}.to output(/Unrecoverable parse error/).to_stdout
+      }
+    end
+    it "should print R error gently" do
+      if r.instance_variable_get(:@platform) =~ /(?!windows-)java$/ then
+        pending("JRuby maybe fail due to stderr output handling")
+      end
+      [
+        ['stop("something wrong!"); print("skip")', 'print("do other")'],
+      ].each{|src|
+        input.replace(src + ['exit()'])
+        expect{r.prompt}.to output(/something wrong\!.*(?!skip).*do other/m).to_stdout
       }
     end
   end

--- a/spec/rinruby_spec.rb
+++ b/spec/rinruby_spec.rb
@@ -325,6 +325,10 @@ shared_examples 'RinRubyCore' do
       super().merge({:interactive => true})
     }
     it "should be interrupted by SIGINT" do
+      if r.instance_variable_get(:@platform) =~ /java$/ then
+        pending("JRuby does not give fully support for signal handling")
+        fail
+      end
       int_invoked = false
       int_handler = Signal::trap(:INT){int_invoked = true}
       printed = []


### PR DESCRIPTION
This PR corresponds to #48, which requests to revise signal INT handling in eval(). To merge this PR, eval execution will be stopped immediately when SIGINT is received, and the signal INT will be propagated to another handler defined previously.