### PR TITLE
Update assign() to support R 4.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ Gemfile.lock
 pkg
 doc
 *~
+.idea/
+coverage/

--- a/lib/rinruby.rb
+++ b/lib/rinruby.rb
@@ -162,7 +162,7 @@ class RinRuby
     raise EngineClosed if (@reader.closed? || @writer.closed?)
     
     @writer.puts <<-EOF
-      assign("#{RinRuby_Env}", new.env(), baseenv())
+      assign("#{RinRuby_Env}", new.env(), envir = globalenv())
     EOF
     @socket = nil
     [:socket_io, :assign, :pull, :check].each{|fname| self.send("r_rinruby_#{fname}")}


### PR DESCRIPTION
The latest version of R no longer supports assigning variables to baseenv(), now updated to globalenv().

See 4.1.0 of https://cran.r-project.org/doc/manuals/r-devel/NEWS.html
"The base environment and its namespace are now locked (so one can no longer add bindings to these or remove from these)."