### PR TITLE
Make usable after Ruby 3.2 on Windows

### DIFF
--- a/lib/rinruby.rb
+++ b/lib/rinruby.rb
@@ -1011,7 +1011,7 @@ print('#{RinRuby_Eval_Flag}.#{run_num}')
         ['bin', 'bin/x64', 'bin/i386'].product(
             cygwin ? [path.gsub(' ','\ '), path] : [path.gsub('\\','/')]).each{|bin_dir, base_dir| 
           r_exe = File::join(base_dir, bin_dir, "Rterm.exe")
-          return %Q<"#{r_exe}"> if File.exists?(r_exe)
+          return %Q<"#{r_exe}"> if File.exist?(r_exe)
         }
       }
       raise "Cannot locate R executable"


### PR DESCRIPTION
Need to use File.exist? since File.exists? has been removed at Ruby 3.2. 
At least, File.exist? has existed since Ruby 2.1, so this change shouldn't cause any problems.